### PR TITLE
Refatoração do cálculo de forcas_par na versão paralela(CPU)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 # ============================================================================
 
 cmake_minimum_required(VERSION 3.15)
-project("gravidade" VERSION 1.4.0
+project("gravidade" VERSION 1.4.1
         DESCRIPTION "Simulacoes de gravidade em Fortran!"
         LANGUAGES Fortran)
 enable_language(Fortran)

--- a/LOG.md
+++ b/LOG.md
@@ -1,5 +1,11 @@
 # LOG.md - Diário de Desenvolvimento
 
+## [2026-07-10] v1.4.1: Refatoração do cálculo de forcas_par na versão paralela (CPU) (PR #20 de jGp34)
+
+- A versão paralela de forcas_par calculava N^2 interações em vez de N(N-1)/2, pois usar a 3a Lei de Newton (Fab = -Fba) em paralelo causava uma race condition ao escrever em forcas(b,:) — o CHANGELOG (v0.2.1) confirma que isso foi uma escolha deliberada para contornar esse bug. Esta PR resolve a race condition com REDUCTION(+:forcas).
+
+---
+
 ## [2026-06-03] v1.4.0: Testes!
 
 - Implementação de testes para validar a execução do programa. Por enquanto constam apenas 2: um que garante que todos os métodos são chamados e outro que verifica a (ordem de) convergência dos métodos. A ideia é ir implementando mais depois.

--- a/src/calcs/forcas/forcas_md.F90
+++ b/src/calcs/forcas/forcas_md.F90
@@ -30,28 +30,27 @@ FUNCTION forcas_par (m, R, G, N, dim, potsoft2) RESULT(forcas)
   REAL(pf), DIMENSION(N, dim) :: forcas
   REAL(pf), DIMENSION(dim)    :: Fab
   INTEGER  :: a, b
-  
+
   forcas = 0.0_pf
 
-  !$OMP PARALLEL SHARED(forcas) PRIVATE(Fab, a, b)
-  !$OMP DO
-  DO a = 1, N
-    DO b = 1, N
-      IF (a==b) THEN
-        CYCLE
-      ENDIF
-      
+  !$OMP PARALLEL DO DEFAULT(NONE) SHARED(m, R, G, N, potsoft2) &
+  !$OMP PRIVATE(a, b, Fab) SCHEDULE(DYNAMIC) REDUCTION(+:forcas)
+  DO a = 2, N
+    DO b = 1, a - 1
       ! Calculo da forca
       Fab = calcular_forca(G, m, R, a, b, potsoft2)
-      
-      ! Adiciona na matriz      
+
+      ! Adiciona na matriz (3a Lei de Newton: Fab = -Fba)
       forcas(a,1) = forcas(a,1) + Fab(1)
       forcas(a,2) = forcas(a,2) + Fab(2)
       forcas(a,3) = forcas(a,3) + Fab(3)
+
+      forcas(b,1) = forcas(b,1) - Fab(1)
+      forcas(b,2) = forcas(b,2) - Fab(2)
+      forcas(b,3) = forcas(b,3) - Fab(3)
     END DO
   END DO
-  !$OMP END DO
-  !$OMP END PARALLEL
+  !$OMP END PARALLEL DO
 
 END FUNCTION forcas_par
 

--- a/src/calcs/forcas/forcas_md.F90
+++ b/src/calcs/forcas/forcas_md.F90
@@ -6,10 +6,11 @@
 !   calculam as forcas do mesmo jeito.
 !
 ! Modificado:
-!   27 de janeiro de 2026
+!   10 de julho de 2026
 !
 ! Autoria:
 !   oap
+!   jGp34
 ! 
 MODULE funcoes_forca_md
 

--- a/src/calcs/forcas/forcas_mi.F90
+++ b/src/calcs/forcas/forcas_mi.F90
@@ -6,10 +6,11 @@
 !   calculam as forcas do mesmo jeito.
 !
 ! Modificado:
-!   27 de janeiro de 2026
+!   10 de julho de 2026
 !
 ! Autoria:
 !   oap
+!   jGp34
 ! 
 MODULE funcoes_forca_mi
 

--- a/src/calcs/forcas/forcas_mi.F90
+++ b/src/calcs/forcas/forcas_mi.F90
@@ -30,28 +30,27 @@ FUNCTION forcas_mi_par (R, G, N, dim, potsoft2) RESULT(forcas)
   REAL(pf), DIMENSION(dim)    :: Fab
   REAL(pf), DIMENSION(N, dim) :: forcas
   INTEGER  :: a, b
-  
+
   forcas = 0.0_pf
 
-  !$OMP PARALLEL SHARED(forcas) PRIVATE(Fab, a, b)
-  !$OMP DO
-  DO a = 1, N
-    DO b = 1, N
-      IF (a==b) THEN
-        CYCLE
-      ENDIF
-
+  !$OMP PARALLEL DO DEFAULT(NONE) SHARED(R, G, N, potsoft2) &
+  !$OMP PRIVATE(a, b, Fab) SCHEDULE(DYNAMIC) REDUCTION(+:forcas)
+  DO a = 2, N
+    DO b = 1, a - 1
       ! Calculo da forca
       Fab = calcular_forca(G, R, a, b, potsoft2)
 
-      ! Adiciona na matriz      
+      ! Adiciona na matriz (3a Lei de Newton: Fab = -Fba)
       forcas(a,1) = forcas(a,1) + Fab(1)
       forcas(a,2) = forcas(a,2) + Fab(2)
       forcas(a,3) = forcas(a,3) + Fab(3)
+
+      forcas(b,1) = forcas(b,1) - Fab(1)
+      forcas(b,2) = forcas(b,2) - Fab(2)
+      forcas(b,3) = forcas(b,3) - Fab(3)
     END DO
   END DO
-  !$OMP END DO
-  !$OMP END PARALLEL
+  !$OMP END PARALLEL DO
 
 END FUNCTION forcas_mi_par
 


### PR DESCRIPTION
A versão paralela de forcas_par calculava N² interações em vez de N(N-1)/2, pois usar a 3ª Lei de Newton (Fab = -Fba) em paralelo causava uma race condition ao escrever em forcas(b,:) — o CHANGELOG (v0.2.1) confirma que isso foi uma escolha deliberada para contornar esse bug. Esta PR resolve a race condition com REDUCTION(+:forcas).